### PR TITLE
#118 Update PHP to 7.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -180,7 +180,7 @@ RUN docker-php-ext-enable xmlrpc
 RUN docker-php-ext-enable zip
 
 RUN docker-php-ext-configure intl
-RUN docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/
+RUN docker-php-ext-configure gd --with-freetype --with-jpeg
 
 
 RUN { \


### PR DESCRIPTION
Remove directory references in docker-php-ext-configure gd params to meet newer PHP requirements.