### PR TITLE
Default wwwroot value set to good url #122

### DIFF
--- a/app/config/sync/moodle/moodle-config.php
+++ b/app/config/sync/moodle/moodle-config.php
@@ -23,7 +23,7 @@ $CFG->dboptions = array (
   'dbcollation' => 'latin1_swedish_ci',
 );
 
-$CFG->wwwroot   = (isset($_ENV['SITE_URL'])) ? $_ENV['SITE_URL'] : 'https://moodle-gamma-950003-dev.apps.silver.devops.gov.bc.ca';
+$CFG->wwwroot   = (isset($_ENV['SITE_URL'])) ? $_ENV['SITE_URL'] : 'https://moodle-950003-dev.apps.silver.devops.gov.bc.ca';
 $CFG->dataroot  = (isset($_ENV['MOODLE_DATA_PATH'])) ? $_ENV['MOODLE_DATA_PATH'] : '/vendor/moodle/moodledata/persistent';
 // $CFG->themedir  = (isset($_ENV['MOODLE_DATA_MOUNT_PATH'])) ? $_ENV['MOODLE_DATA_MOUNT_PATH'].'/theme' : '/vendor/moodle/moodledata/theme';
 $CFG->admin     = 'admin';


### PR DESCRIPTION
Apparently the SITE_URL env variable is not being set? so it's picking up the default, and that has a -gamma in it that I don't think exists, or at least it's not the correct dev server. I don't actually think this will fix our error, but maybe??