### PR TITLE
Update Dataflows Plugin

### DIFF
--- a/github-workflow-test.txt
+++ b/github-workflow-test.txt
@@ -13,3 +13,4 @@ Kick to upgrade dataflows plugin
 Kick to upgrade dataflows plugin, again
 Kick to upgrade dataflows plugin
 again
+Kick to upgrade dataflows plugin


### PR DESCRIPTION
There was a bug in the dataflows plugin that was stripping headers from the cURL call. Pull 669 fixes it apparently.