### PR TITLE
Update moodle-dc-persistent-template.json to remove restartPolicy

### DIFF
--- a/openshift/app/moodle-dc-persistent-template.json
+++ b/openshift/app/moodle-dc-persistent-template.json
@@ -180,7 +180,6 @@
               {
                 "image": "${IMAGE_REGISTRY}/${BUILD_NAMESPACE}/${IMAGE_STREAM_TAG}",
                 "name": "${APP_NAME}",
-                "restartPolicy": "Always",
                 "imagePullPolicy": "Always",
                 "livenessProbe": {
                   "httpGet": {


### PR DESCRIPTION
Fix for latest OpenShift upgrade to remove deprecated container restartPolicy.